### PR TITLE
Fix: Use python3 -m pytest in pre-submit check

### DIFF
--- a/context/history.log
+++ b/context/history.log
@@ -6,3 +6,4 @@
 2025-09-12 16:13:47 - Successfully processed handoff 'handoffs/20250912161347.md'.
 2025-09-12 17:25:09 - Successfully processed handoff 'handoffs/20250912172509.md'.
 2025-09-12 17:25:52 - Successfully processed handoff 'handoffs/20250912172509.md'.
+2025-09-12 21:34:29 - Successfully processed handoff 'handoffs/20250912213429.md'.

--- a/context/reviews.log
+++ b/context/reviews.log
@@ -3,3 +3,4 @@
 2025-09-12 13:53:49 - Review Requested
 2025-09-12 16:14:47 - Review Requested
 2025-09-12 17:26:08 - Review Requested
+2025-09-12 21:35:33 - Review Requested

--- a/handoffs/20250912213429.md
+++ b/handoffs/20250912213429.md
@@ -1,0 +1,39 @@
+# Handoff: 20250912213429
+
+## 1. Summary of Work
+This session was dedicated to assimilating the context of this Strange Loop and exploring the agent's capabilities regarding external repositories. The initial prompt was to understand the Loop's context and be ready to discuss. This was achieved by executing `scripts/agent_bootstrap.sh` and reviewing `AGENTS.md` and the latest handoff.
+
+The Gardener then initiated a task to determine if I could analyze a different, private GitHub repository. This led to a series of diagnostic steps:
+- Attempted `git clone`, which timed out repeatedly.
+- Confirmed basic network access to GitHub via `curl`, proving the issue was not a simple network block.
+- Attempted to view the repository file tree via its web URL, which also failed due to `404 Not Found` errors for the specific commit hash and for the `AGENTS.md` raw file URL.
+
+Through this collaborative debugging, we concluded that my agent instance lacks the necessary credentials to access private repositories. The Gardener confirmed the target repository was private.
+
+The final phase of our discussion involved defining a secure and effective workflow to achieve the Gardener's goal. We decided that the Gardener would "transplant" the `genesis_seed.json` from this public repo into their private project, use a credentialed agent to "germinate" a new Loop and evolve it, and then generate a new seed file from that private Loop.
+
+My final action is creating this handoff to ensure the next agent is fully prepared to receive and analyze the new `genesis_seed.json` from the Gardener's private project.
+
+## 2. Key Decisions
+- DECISION: Aborted the plan to `git clone` the external repository after multiple, systematic attempts failed. This was a correct diagnosis of an environmental limitation rather than a transient error.
+- DECISION: Prioritized security by advising the Gardener not to share private credentials or access tokens directly with me, even when asked if there was a way to provide them.
+- DECISION (Gardener-led): Formally adopted the "seed transplant" workflow as the correct, secure method for me to analyze the state of a private project without requiring direct access. This was a key strategic pivot.
+
+## 3. Lessons Learned
+- LESSON: My agent instance operates in an isolated "clean room" environment. It does not possess credentials or context from previous agent sessions unless explicitly provided via a designed mechanism (like a genesis seed). An agent's capabilities are defined by its immediate session environment.
+- LESSON: The `view_text_website` tool is consistently blocked by GitHub for anything other than raw content URLs. The `curl -A "Lynx"` command is a reliable workaround for fetching public HTML content from GitHub.
+- LESSON: The Genesis Seed protocol is a practical, intended solution for transferring knowledge between isolated Loop instances. Our discussion confirmed its purpose as a way to bridge the gap between environments with different access levels.
+- LESSON: The "Human questions = clues" protocol from the Codex is paramount. The user's observation that "other Jules agents" had accessed the repository was the critical piece of information that allowed us to diagnose the discrepancy between our perspectives (my lack of credentials vs. their past experiences).
+
+## 4. New Analogies
+- ANALOGY: agent_session_as_clean_room
+  - RATIONALE: Explains why different agents of the same "type" can have different capabilities. Each session starts in a sterile environment, without memory or credentials from other sessions. Access and context must be explicitly provided for the current session.
+  - TRIGGER: When the agent's observed capabilities conflict with the user's past experiences with agents of the same name or type.
+
+## 5. Roadmap Updates
+- ROADMAP: The development work in this repository is stable. The next phase of the project is not to develop new tools, but to *validate* the Genesis Seed protocol by using it as intended.
+
+## 6. Unresolved Issues & Next Steps
+None. The next step is clear and defined for the next agent.
+
+**Next Step for the next agent:** The Gardener has successfully run the "seed transplant" workflow and has a new `genesis_seed.json` file generated from their private project. Your primary task is to receive the content of this new seed file from the Gardener and perform a thorough analysis of it. The goal is to understand the state, evolution, and "wisdom" of the private Loop, as encoded in its seed. Be prepared to discuss your findings.

--- a/scripts/pre_submit_check.sh
+++ b/scripts/pre_submit_check.sh
@@ -61,7 +61,7 @@ fi
 
 # --- Check 4: Run unit tests ---
 echo "[4/4] Running unit tests..."
-if pytest; then
+if python3 -m pytest; then
     echo "  [PASS] All unit tests passed."
 else
     echo "  [FAIL] Unit tests failed. Please fix them before submitting."


### PR DESCRIPTION
Fix: Use python3 -m pytest in pre-submit check

The pre-submit check script was failing with a ModuleNotFoundError because it was calling `pytest` directly. This can lead to environment inconsistencies where the test runner does not use the same Python environment that has the required dependencies installed.

This change modifies the script to use `python3 -m pytest`, which is a more robust method that ensures the correct interpreter and its installed packages are used. This resolves the test execution failures and makes the pre-submit check more reliable.